### PR TITLE
Update melee.json

### DIFF
--- a/data/json/items/melee.json
+++ b/data/json/items/melee.json
@@ -425,7 +425,7 @@
     "to_hit": 1,
     "color": "yellow",
     "symbol": "/",
-    "material": [ "plastic" ],
+    "material": [ "wood" ],
     "techniques": [ "WBLOCK_1" ],
     "volume": 5,
     "bashing": 4,


### PR DESCRIPTION

#### Summary
<!--
A one-line description of your change that will be extracted and added to the [project changelog](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt).

The format is (ignore the square brackets): ```SUMMARY: [Category] "[description]"```

The categories to choose from are:

* Features
* Content
* Interface
* Mods
* Balance
* Bugfixes
* Performance
* Infrastructure
* Build
* I18N

Example: ```SUMMARY: Content "Adds new mutation category 'Mouse'"```

See the [Changelog Guidelines](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md) for explanations of the categories.
-->
```SUMMARY: Balance "Broom material changed from plastic to wood."```

#### Purpose of change
<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```
If it *fully* resolves an issue, link it like: ```Fixes #1234```
Even if the issue describes the problem, please provide a few-sentence summary here.
Example: ```Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.```
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
Don't put the backticks around the `#` and issue or pull request number to allow the GitHub automatically reference to it.
-->
Many of the recipes that require a broom have an alternative of pool cue, mop or stick, strongly suggesting that the intended material is essentially a long wooden stick - this is even mentioned in several descriptions. Broom handles are also frequently made of wood in the real world. However, the current material is plastic.

#### Describe the solution
<!--
How does the feature work, or how does this fix a bug?
The easier you make your solution to understand, the faster it can get merged.
-->
Broom material is changed to wood, to be in line with the relevant recipes.

#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->
Removing the possibility of a broom from the relevant recipes was also a possibility, especially for all the items where the description explicitly mentions its made of wood.

#### Additional context
<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.
-->
